### PR TITLE
[hotfix] fix testEnv

### DIFF
--- a/__tests__/testEnv.js
+++ b/__tests__/testEnv.js
@@ -1,4 +1,4 @@
 process.env.KRAKENFLEX_SERVICE_URL = 'service-url';
 process.env.KRAKENFLEX_API_KEY = 'token';
 process.env.KRAKENFLEX_SITE_ID = 'test-site-id';
-process.env.KRAKENFLEX_DATE_LIMIT = 'example-date';
+process.env.KRAKENFLEX_DATE_LIMIT = '2023-08-14T19:28:14.115Z';


### PR DESCRIPTION
This PR sets the ```KRAKENFLEX_DATE_LIMIT``` with the valid date format for tests.